### PR TITLE
Add an Unassign all button

### DIFF
--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1104,7 +1104,7 @@ $(document).ready(function() {
                     >
                 [[ assignment_mode ? 'Stop assigning' : 'Assign bells' ]]
             </button>
-            <button class="btn btn-outline-primary w-100"
+            <button class="btn btn-outline-primary w-100 mt-2 mb-n1"
                     v-if="assignment_mode"
                     @click="unassign_all"
                     >

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1027,6 +1027,15 @@ $(document).ready(function() {
                 }
             },
 
+            unassign_all: function() {
+                if (window.tower_parameters.anonymous_user) {
+                    return
+                }; // don't do anything if not logged in
+                for (const bell of bell_circle.$refs.bells){
+                    bell.unassign();
+                }
+            },
+
             rotate_to_assignment: function() {
                 if (window.tower_parameters.anonymous_user) {
                     return
@@ -1094,6 +1103,12 @@ $(document).ready(function() {
                     @click="toggle_assignment"
                     >
                 [[ assignment_mode ? 'Stop assigning' : 'Assign bells' ]]
+            </button>
+            <button class="btn btn-outline-primary w-100"
+                    v-if="assignment_mode"
+                    @click="unassign_all"
+                    >
+                Unassign all
             </button>
         </span>
     </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10487726/91898194-46c6c200-ec93-11ea-942b-598995110102.png)

This only appears at the moment when you are in assignment mode, but does cause an increase in the Users section header. I'm not sure where else to put it / size it.

Since there is now a persistent assignment (be35768e) the trick some practices I've been to use of changing the number of bells in order to clear all current assignments won't work.
