### PR TITLE
Make clients track users by user ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ What follows is a incomplete list of events — these should be only the events 
 | Event                    | Payload                                                                  | Description                                                                           |
 | ---                      | ---                                                                      | ---                                                                                   |
 | `c_join`                 | `{tower_id: Int, user_token: Str, anonymous_user: Bool}`                 | User joined a tower.                                                                  |
-| `s_user_entered`         | `{user_name: Str}`                                                       | Server relayed user entering.                                                         |
+| `s_user_entered`         | `{user_id: Int, username: Str}`                                          | Server relayed user entering.                                                         |
 | `c_user_left`            | `{user_name: Str, user_token: Str, anonymous_user: Bool, tower_id: Int}` | User left a tower.                                                                    |
-| `s_user_left`            | `{user_name: Str}`                                                       | Server relayed user leaving.                                                          |
+| `s_user_left`            | `{user_id: Int, username: Str}`                                          | Server relayed user leaving.                                                          |
 | `c_request_global_state` | `{tower_id: Int}`                                                        | Client requested tower state.                                                         |
 | `s_global_state`         | `{global_bell_state: [Bool]}`                                            | Server sent current tower state.                                                      |
-| `s_set_userlist`         | `{user_list: [Str]}`                                                     | Server set list of users in tower.                                                    |
+| `s_set_userlist`         | `{user_list: [{user_id: Int, username: Str}]}`                           | Server set list of users in tower.                                                    |
 | `c_bell_rung`            | `{bell: Int, stroke: Bool, tower_id: Int}`                               | User rang a bell.                                                                     |
 | `s_bell_rung`            | `{global_bell_state: [Bool], who_rang: Int, disagreement: Bool}`         | Server relayed bell ringing.                                                          |
 | `c_assign_user`          | `{bell: Int, user: Str, tower_id: Int}`                                  | User assigned someone to a bell.                                                      |

--- a/app/listeners.py
+++ b/app/listeners.py
@@ -108,7 +108,8 @@ def on_join(json):
         emit('s_host_mode', {'tower_id': tower_id,
                              'new_mode': tower.host_mode})
 
-        emit('s_user_entered', { 'user_name': current_user.username },
+        emit('s_user_entered', {'user_id': current_user.id,
+                                'username': current_user.username },
              broadcast=True, include_self = True, room=json['tower_id'])
 
     # Check if there are any hosts in the room, and if not, make sure that
@@ -157,7 +158,8 @@ def on_user_left(json):
         return
 
     tower.remove_user(user_id)
-    emit('s_user_left', { 'user_name': current_user.username },
+    emit('s_user_left', {'user_id': current_user.id,
+                         'username': current_user.username },
          broadcast=True, include_self=True, room=tower_id)
 
     # Now that the user is gone, check if there are any hosts left. If not, make sure

--- a/app/listeners.py
+++ b/app/listeners.py
@@ -93,7 +93,8 @@ def on_join(json):
         if current_user.username in tower.users.keys():
             log('SETUP User already present')
             tower.remove_user(current_user.id)
-            emit('s_user_left', {'user_name': current_user.username},
+            emit('s_user_left', {'user_id': current_user.id},
+                                 'username': current_user.username},
                                 broadcast = True,
                                 include_self = True,
                                 room = tower_id)

--- a/app/listeners.py
+++ b/app/listeners.py
@@ -72,7 +72,7 @@ def on_join(json):
     log('SETUP Joined tower:',tower_id)
 
     # Whether the user is anonymous or not, send them the list of current users
-    emit('s_set_userlist',{'user_list': tower.user_names})
+    emit('s_set_userlist',{'user_list': tower.user_json})
 
     # If the user is anonymous, mark them as an observer and set some cookies
     if current_user.is_anonymous:

--- a/app/models.py
+++ b/app/models.py
@@ -417,6 +417,11 @@ class Tower:
     def user_names(self):
         return list(self._users.values())
 
+    @property 
+    def user_json(self):
+        # Returns an object appropriate for sending with s_set_userlist
+        return [{'user_id': id, 'username': username} for id, username in self._users.items()]
+
     @property
     def host_mode(self):
         return self._host_mode

--- a/app/routes.py
+++ b/app/routes.py
@@ -76,6 +76,7 @@ def tower(tower_id, decorator=None):
     # Pass in both the tower and the user_name
     return render_template('ringing_room.html',
                             tower = tower,
+                            user_id = '' if current_user.is_anonymous else current_user.id,
                             user_name = '' if current_user.is_anonymous else current_user.username,
                             user_email = '' if current_user.is_anonymous else current_user.email,
                             server_ip=get_server_ip(tower_id),

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -80,6 +80,10 @@ socketio.on('s_bell_rung', function(msg, cb) {
 socketio.on('s_set_userlist', function(msg, cb) {
     console.log('s_set_userlist: ' + msg.user_list);
     bell_circle.$refs.users.user_names = msg.user_list;
+    msg.user_list.forEach((user,index) => {
+        bell_circle.$refs.users.add_user({user_id: parseInt(user.user_id),
+                                          username: user.username});
+    });
 });
 
 // User entered the room
@@ -1142,12 +1146,18 @@ $(document).ready(function() {
                 console.log('cur_user is: ', this.cur_user);
             },
 
-            remove_user: function(user) {
-                console.log('removing user: ' + user);
-                const index = this.users.indexOf(user);
-                if (index > -1) {
-                    this.users.splice(index, 1);
-                }
+            remove_user: function(user_id) {
+                console.log('removing user: ' + user_id);
+
+                var user_index
+                this.users.forEach((u,index) => {
+                    if (u.user_id === user_id) {
+                        user_index = index;
+                        return;
+                    }
+                });
+                this.users.splice(user_index,1);
+
             },
         },
 

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1040,7 +1040,6 @@ $(document).ready(function() {
             },
 
             select_user: function() {
-                console.log('select user triggered')
                 if (window.tower_parameters.anonymous_user) {
                     return
                 }; // don't do anything if not logged in

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1146,12 +1146,12 @@ $(document).ready(function() {
                 console.log('cur_user is: ', this.cur_user);
             },
 
-            remove_user: function(user_id) {
-                console.log('removing user: ' + user_id);
+            remove_user: function(user) {
+                console.log('removing user: ', user);
 
                 var user_index
                 this.users.forEach((u,index) => {
-                    if (u.user_id === user_id) {
+                    if (u.user_id === user.user_id) {
                         user_index = index;
                         return;
                     }

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -242,6 +242,11 @@ $(document).ready(function() {
             cur_user: function() {
                 return this.$root.$refs.users.cur_user;
 
+
+            },
+
+            assigned_user_name: function() {
+                return this.$root.$refs.users.get_user_name(this.assigned_user);
             },
 
             left_side: function() {
@@ -391,8 +396,8 @@ $(document).ready(function() {
                             v-if="assignment_mode || assigned_user">
                         <span class="assigned_user">
                             [[ (assignment_mode) ?
-                                ((assigned_user) ? assigned_user : '(none)')
-                                : assigned_user ]]
+                                ((assigned_user) ? assigned_user_name : '(none)')
+                                : assigned_user_name ]]
                         </span>
                     </button>
                     <button class='btn btn-sm btn_number'
@@ -424,8 +429,8 @@ $(document).ready(function() {
                             >
                         <span class="assigned_user_name">
                             [[ (assignment_mode) ?
-                               ((assigned_user) ? assigned_user : '(none)')
-                               : assigned_user ]]
+                               ((assigned_user) ? assigned_user_name : '(none)')
+                               : assigned_user_name ]]
                         </span>
                     </button>
                     <button class="btn btn-sm btn_unassign"
@@ -1153,15 +1158,26 @@ $(document).ready(function() {
             remove_user: function(user) {
                 console.log('removing user: ', user);
 
-                var user_index
+                var user_index = -1
                 this.users.forEach((u,index) => {
                     if (u.user_id === user.user_id) {
                         user_index = index;
                         return;
                     }
                 });
-                this.users.splice(user_index,1);
+                if (user_index !== -1) {
+                    this.users.splice(user_index,1);
+                    }
+            },
 
+            get_user_name: function(user_id) {
+                var username
+                this.users.forEach((u,index) => {
+                    if (u.user_id === user_id){
+                        username = u.username;
+                    };
+                });
+                return username;
             },
         },
 

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1034,10 +1034,25 @@ $(document).ready(function() {
                 this.assigned_bells = []
             },
 
+            select_user: function() {
+                console.log('select user triggered')
+                if (window.tower_parameters.anonymous_user) {
+                    return
+                }; // don't do anything if not logged in
+                if (this.$root.$refs.controls.lock_controls) {
+                    return
+                };
+                this.$root.$refs.users.selected_user = this.user_id;
+            },
+
+
         },
 
         template: `
 <li class="list-group-item list-group-item-action"
+    :class="{assignment_active: selected,
+             active: selected}"
+    @click="select_user"
     >
     [[ username ]]
 </li>
@@ -1128,22 +1143,11 @@ $(document).ready(function() {
                 this.$root.rotate(rotate_to);
             },
 
-            select_user: function(user) {
-                if (window.tower_parameters.anonymous_user) {
-                    return
-                }; // don't do anything if not logged in
-                if (this.$root.$refs.controls.lock_controls) {
-                    return
-                };
-                this.selected_user = user;
-            },
-
             add_user: function(user) {
+                console.log('adding user: ', user)
                 if (!this.users.includes(user)) {
                     this.users.push(user);
                 }
-                console.log('current users list: ', this.users);
-                console.log('cur_user is: ', this.cur_user);
             },
 
             remove_user: function(user) {
@@ -1213,7 +1217,6 @@ $(document).ready(function() {
                    :username="cur_user_name"
                    :selected="selected_user === cur_user && assignment_mode"
                    v-if="!window.tower_parameters.anonymous_user"
-                   @click="select_user(cur_user)"
                    class="cur_user"
                    ></user_data>
         <li v-if="$root.$refs.controls.lock_controls"
@@ -1225,7 +1228,6 @@ $(document).ready(function() {
               :user_id="u.user_id"
               :username="u.username"
               :selected="selected_user === u.user_id && assignment_mode"
-              @click="select_user(u)"
               ></user_data>
     </ul>
 </div>

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -26,7 +26,6 @@ var logger = function() {
 
     return pub;
 }();
-
 // logger.disableLogger()
 
 // Set up socketio instance
@@ -993,6 +992,45 @@ $(document).ready(function() {
     </div>
 </div>
 `
+    });
+
+    // user holds individual user data
+    Vue.component('user', {
+
+        props: ['user_id', 'username'],
+
+        data: function(){
+            return {
+                assigned_bells: [],
+            }
+        },
+
+        methods: {
+
+            assign_bell: function(bell) {
+                this.assigned_bells.push(bell);
+                this.$root.$refs.bells[bell].assigned_user = this.user_id;
+            },
+
+            unassign_bell: function(bell){
+                const bell_index = this.assigned_bells.indexOf(bell);
+                if (bell_index === -1) {
+                    console.log('Tried to unassign ' + self.username + ' from bell ' + bell);
+                    return
+                }
+                this.assigned_bells.splice(index, 1)
+                this.$root.$refs.bells[bell].assigned_user = null
+            },
+
+            unassign_all: function(bell){
+                this.assigned_bells.forEach((bell, index) => {
+                    this.$root.$refs.bells[bell].assigned_user = null
+                });
+                this.assigned_bells = []
+            },
+
+        },
+
     });
 
 

--- a/app/templates/ringing_room.html
+++ b/app/templates/ringing_room.html
@@ -34,6 +34,7 @@
             size: parseInt({{tower.n_bells}}),
             observers: parseInt({{tower.observers}}),
             assignments: {{tower.assignments_as_list() | safe }},
+            cur_user_id: "{{user_id}}",
             cur_user_name: "{{user_name}}",
             cur_user_email: "{{user_email}}",
             anonymous_user: {{'true' if current_user.is_anonymous or listen_link else 'false'}},


### PR DESCRIPTION
When this PR is complete, RR clients will keep track of users in a tower by their user ID (which is globally unique) rather than their username (which is not). This resolves #161.

This will be accomplished by:

- Implementing `Vue.component('user')`, which tracks user IDs, usernames, and assigned bells.
- Switching the SocketIO listeners on the client side to handle all assignment via the new Vue component.
- Updating `listeners.py` to send ID+username pairs for entering; user-ID only for assigning, leaving.