### PR TITLE
Make '0' the unassigned 'null' value not the empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,10 @@ What follows is a incomplete list of events — these should be only the events 
 | `s_set_userlist`         | `{user_list: [{user_id: Int, username: Str}]}`                           | Server set list of users in tower.                                                    |
 | `c_bell_rung`            | `{bell: Int, stroke: Bool, tower_id: Int}`                               | User rang a bell.                                                                     |
 | `s_bell_rung`            | `{global_bell_state: [Bool], who_rang: Int, disagreement: Bool}`         | Server relayed bell ringing.                                                          |
-| `c_assign_user`          | `{bell: Int, user: Str, tower_id: Int}`                                  | User assigned someone to a bell.                                                      |
-| `s_assign_user`          | `{bell: Int, user: Str}`                                                 | Server sent bell assignment.                                                          |
-| `c_audio_change`         | `{new_audio: ("Tower"\| "Hand"), tower_id: Int}`                         | User changed audio type.                                                              |
-| `s_audio_change`         | `{new_audio: ("Tower"\| "Hand")}`                                        | Server sent audio state.                                                              |
+| `c_assign_user`          | `{bell: Int, user: Int, tower_id: Int}`                                  | User assigned someone to a bell.                                                      |
+| `s_assign_user`          | `{bell: Int, user: Int}`                                                 | Server sent bell assignment.                                                          |
+| `c_audio_change`         | `{new_audio: ("Tower" \| "Hand"), tower_id: Int}`                         | User changed audio type.                                                              |
+| `s_audio_change`         | `{new_audio: ("Tower" \| "Hand")}`                                        | Server sent audio state.                                                              |
 | `c_host_mode`            | `{new_mode: Bool, tower_id: Int}`                                        | User toggled host mode.                                                               |
 | `s_host_mode`            | `{tower_id: Int, new_mode: Bool}`                                        | Server sent host mode.                                                                |
 | `c_size_change`          | `{new_size: Int, tower_id: Int}`                                         | User changed tower size.                                                              |

--- a/app/models.py
+++ b/app/models.py
@@ -307,6 +307,11 @@ class UserTowerRelation(db.Model):
 # Keep track of towers
 
 
+# Constant to hold the value that Ringing Room uses to denote a bell not being assigned to any user.
+# `0` is therefore a reserved user ID and cannot be taken by any user, even Wheatley (who is user `-1`)
+UNASSIGNED_BELL = 0
+
+
 class Tower:
     def __init__(self, name, tower_id=None, n=8, host_mode_enabled=False):
         if not tower_id:
@@ -319,7 +324,7 @@ class Tower:
         self._bell_state = [True] * n
         self._audio = True
         self._users = {}
-        self._assignments = {i+1: '' for i in range(n)}
+        self._assignments = {i+1: UNASSIGNED_BELL for i in range(n)}
         self._observers = set()
         self._host_mode = False
         self._host_mode_enabled = host_mode_enabled
@@ -408,7 +413,7 @@ class Tower:
             for (bell, assignment) in self._assignments.items():
                 if assignment == user_name:
                     # unassign the user from all bells
-                    self._assignments[bell] = ''
+                    self._assignments[bell] = UNASSIGNED_BELL
             del self._users[int(user_id)]
         except ValueError: log('Value error when removing user from tower.')
         except KeyError: log("Tried to remove user that wasn't there")
@@ -452,7 +457,7 @@ class Tower:
                 self._assignments.pop(k)
         else: # add new keys for new assignments
             for k in range(self._n + 1, new_size + 1):
-                self._assignments[k] = ''
+                self._assignments[k] = UNASSIGNED_BELL
 
         self._n = new_size
         self._bell_state = [True] * new_size


### PR DESCRIPTION
Resolves #165 (if paired with giving Wheatley user ID `-1`).  If you guys have a better strategy, then let me know and I'll implement it instead `:)`.