### PR TITLE
Feature: API Version endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Ringing Room supplies a basic API for use in 3rd-party apps.
 
 | Endpoint                         | Method   | Description                            |
 | ---                              | ---      | ---                                    |
+| `/api/version`                   | `GET`    | Get API version information            |
 | `/api/tokens`                    | `POST`   | Get bearer token                       |
 | `/api/tokens`                    | `DELETE` | Revoke bearer token                    |
 | `/api/user`                      | `GET`    | Get current user details               |
@@ -43,6 +44,14 @@ Ringing Room supplies a basic API for use in 3rd-party apps.
 | `/api/tower/<tower_id>`          | `GET`    | Get connection details for `tower_id`  |
 | `/api/tower`                     | `POST`   | Create new tower                       |
 | `/api/tower/<tower_id>`          | `DELETE` | Delete tower (if permitted)            |
+
+### Version
+
+`GET /api/version`: Gets version information. Responds with the fields:
+
+- `version`: the overall RR version (which takes the form `YY.WW`, for year and week of release)
+- `api-version`: the api version, which is semantically versioned
+- `socketio-version`: the socketio version, which is semantically versioned
 
 ### Authorization
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,4 +1,5 @@
 from flask import jsonify, request, url_for
+from config import Config
 from app.models import User, TowerDB, UserTowerRelation, Tower, get_server_ip, towers
 from app.extensions import db
 from app.api import bp
@@ -6,6 +7,16 @@ from app.api.errors import error_response, bad_request
 from app.api.auth import token_auth
 from flask_login import current_user
 
+# version endpoint
+
+@bp.route('/version', methods=['GET'])
+def get_version():
+    data = {
+        "version": Config.RR_VERSION,
+        "api-version": Config.RR_API_VERSION,
+        "socketio-version": Config.RR_SOCKETIO_VERSION
+    }
+    return jsonify(data)
 
 # user endpoints
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,6 +1,7 @@
 from flask import render_template, send_from_directory, abort, flash, redirect, url_for, session, request
 from flask_login import login_user, logout_user, current_user, login_required
 from app import app
+from config import Config
 from app.extensions import db, log
 from app.models import User, UserTowerRelation, get_server_ip, towers
 from flask_login import current_user, login_user, logout_user, login_required
@@ -90,7 +91,8 @@ def tower(tower_id, decorator=None):
 
 @app.route('/about')
 def about():
-    return render_template('about.html')
+    return render_template('about.html',
+                           version=Config.RR_VERSION)
 
 
 @app.route('/help')

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -11,7 +11,7 @@
 
 <p>Welcome to the Ringing Room! This is a site built for change ringers to continue ringing with one another even when socially distanced. It is under development currently, and new features may show up with little warning. Please <a href="/contact">contact us</a> if you have any issues or suggestions.</p>
 
-<p>You are using version <b>20.36</b>, released on <b>3 September 2020</b>.</p>
+<p>You are using version <b>{{version}}</b>.</p>
 
 <h3> The developers </h3>
 

--- a/config.py
+++ b/config.py
@@ -8,6 +8,12 @@ load_dotenv(os.path.join(basedir,'.env'))
 
 class Config(object):
 
+    RR_VERSION = "20.39"
+
+    RR_API_VERSION = "1.0"
+
+    RR_SOCKETIO_VERSION = "1.0"
+
     SECRET_KEY = os.getenv('SECRET_KEY') or 's7WUt93.ir_bFya7'
 
     SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL') or \


### PR DESCRIPTION
This resolves #167. It exposes `/api/version`, which returns:

- `version`: the overall RR version (which takes the form `<Year>.<Week>` of release)
- `api-version`: the api version, which is semantically versioned (and currently set to 1.0)
- `socketio-version`: the socketio version, which is semantically versioned (and currently set to 1.0)

All of these are set as variables in `config.py` and thus accessible generally throughout the application.