### PR TITLE
Correct assignment of opposite handbell pairs

### DIFF
--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -2530,14 +2530,14 @@ $(document).ready(function() {
 
                 // Collect the numbers of the bells that belong to the current user
                 let current_user_bells = [];
-
                 for (var i = 0; i < this.$refs.bells.length; i++) {
                     const bell = this.$refs.bells[i];
-
                     if (bell.assigned_user == window.tower_parameters.cur_user_id) {
                         current_user_bells.push(bell.number);
                     }
                 }
+                // Make sure that the bells are always in ascending order
+                current_user_bells.sort();
 
                 /* Use these to decide which bells should be in the user's left and right hands. */
                 // CASE 1: No bells are assigned
@@ -2571,7 +2571,7 @@ $(document).ready(function() {
                     var left_hand_bell;
                     var right_hand_bell;
 
-                    if (second_bell - first_bell < first_bell + this.bells.length - second_bell) {
+                    if (second_bell - first_bell <= first_bell + this.bells.length - second_bell) {
                         // The shortest way to pair the bells does not wrap round the 'end' of the
                         // circle
                         left_hand_bell = second_bell;


### PR DESCRIPTION
Previously, if a user were assigned to two bells on direct opposite sides of the ringing circle then the bells would be assigned like this:
```
R->4 5
 3     6
   2 1<-L
```
which (as Nigel Goodship pointed out) is very counterintuitive.  Now the left/right keys are reversed in this case, so that the bell in the bottom-right corner is in the user's right hand.