### PR TITLE
Quality of life improvements to the Wheatley box

### DIFF
--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1395,7 +1395,8 @@ $(document).ready(function() {
                    id="wheatley_peal_speed_mins"
                    v-model="peal_speed_mins"
                    v-on:change="on_change_peal_speed"
-                   style="border: none; width: 2.1em" step="5"/>min
+                   style="border: none; width: 2.1em; text-align: right;"
+                   step="5"/>min
         </p>
 
         <hr/>

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1229,8 +1229,9 @@ $(document).ready(function() {
         template: `
 <div class="card mb-3" id="wheatley" v-if="enabled">
     <!-- Wheatley header -->
-    <div class="card-header">
+    <div class="card-header d-flex">
         <h2 style="display: inline; cursor: pointer;"
+            class="mr-auto"
             id="wheatley_header"
             data-toggle="collapse"
             data-target="#wheatley_body"
@@ -1238,6 +1239,15 @@ $(document).ready(function() {
         >
             Wheatley
         </h2>
+        <!-- Fill in Wheatley -->
+        <button class="btn btn-outline-primary btn-block"
+                style="width: max-content;"
+                :class="{disabled: settings_panel_disabled}"
+                @click="fill_bells"
+                title="Assign all unassigned bells to Wheatley"
+        >
+            Fill In
+        </button>
     </div>
     <div class="card-body collapse show"
          id="wheatley_body"
@@ -1414,16 +1424,6 @@ $(document).ready(function() {
         </label>
 
         <hr/>
-
-        <!-- Fill in Wheatley -->
-        <button class="btn btn-outline-primary btn-block"
-                style="margin-top: 1rem"
-                :class="{disabled: settings_panel_disabled}"
-                @click="fill_bells"
-                title="Assign all unassigned bells to Wheatley"
-        >
-            Fill Unassigned Bells
-        </button>
 
         <!-- Reset Wheatley -->
         <button class="btn btn-outline-primary btn-block"

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -962,7 +962,6 @@ $(document).ready(function() {
             },
 
             peal_speed: function () {
-                console.log("Peal speed changed", this.peal_speed);
                 // Clamp the peal speed to a reasonable range
                 const last_peal_speed = this.peal_speed;
                 this.peal_speed = Math.max(Math.min(last_peal_speed, 300), 60);
@@ -1367,6 +1366,25 @@ $(document).ready(function() {
         <br/>
         -->
 
+        <!-- Peal Speed -->
+        <p style="margin-bottom: 0.6rem;">Peal Speed:
+            <input type="number"
+                   id="wheatley_peal_speed_hours"
+                   v-model="peal_speed_hours"
+                   v-on:change="on_change_peal_speed"
+                   style="border: none; width: 1.5em"
+            />hr
+            <input type="number"
+                   id="wheatley_peal_speed_mins"
+                   v-model="peal_speed_mins"
+                   v-on:change="on_change_peal_speed"
+                   style="border: none; width: 2.1em; text-align: right;"
+                   step="5"
+            />min
+        </p>
+
+        <hr/>
+
         <!-- Up Down In -->
         <input type="checkbox"
                v-model="use_up_down_in"
@@ -1388,31 +1406,12 @@ $(document).ready(function() {
                name="stop_at_rounds"
                :disabled="settings_panel_disabled"
                />
-        <label style="margin-bottom: 0;"
+        <label style=" margin-bottom: 0.1rem;"
                for="stop_at_rounds"
                title="If checked, Wheatley will stand his bells when rounds occurs when ringing method."
         >
             Stop at rounds
         </label>
-
-        <hr/>
-
-        <!-- Peal Speed -->
-        <p>Peal Speed:
-            <input type="number"
-                   id="wheatley_peal_speed_hours"
-                   v-model="peal_speed_hours"
-                   v-on:change="on_change_peal_speed"
-                   style="border: none; width: 1.5em"
-            />hr
-            <input type="number"
-                   id="wheatley_peal_speed_mins"
-                   v-model="peal_speed_mins"
-                   v-on:change="on_change_peal_speed"
-                   style="border: none; width: 2.1em; text-align: right;"
-                   step="5"
-            />min
-        </p>
 
         <hr/>
 


### PR DESCRIPTION
Small quality of life improvements to the Wheatley box:
- The text for the minutes value of peal speed is now aligned to the right, so that the units column is always in the same place.
- There's now a button to assign all unassigned bells to Wheatley.  I wonder if this would be better going next to the `Unassign all` button - I'm not sure, because if you're bulk assigning Wheatley you're probably going to specify a method anyway and will therefore have to interact with the Wheatley box anyway.
- Peal speed has been pushed up the box, since I think it will be used more than `up-down-in`/`stop at rounds`.