### PR TITLE
Temporarily remove Wheatley's Rowgen Selector

### DIFF
--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1280,7 +1280,7 @@ $(document).ready(function() {
 
         <div id="wheatley_row_gen_box">
             <!-- Wheatley row gen type toggle -->
-            <div class="btn-group btn-block btn-group-toggle">
+            <div class="d-none btn-group btn-block btn-group-toggle">
                 <label class="btn btn-outline-primary"
                        style="border-bottom-left-radius: 0;"
                        :class="{active: row_gen_panel == 'method',

--- a/app/static/sass/ringing_room.scss
+++ b/app/static/sass/ringing_room.scss
@@ -349,9 +349,10 @@ input[type=range]::slider-thumb {
 }
 
 #wheatley_row_gen_box_inner {
-    padding: 5px; 
-    border: 1px solid;
-    border-top: none;
+    // Uncomment to re-add rowgen selector
+    // padding: 5px; 
+    // border: 1px solid;
+    // border-top: none;
     border-bottom-right-radius: 0.25rem;
     border-bottom-left-radius: 0.25rem;
 }


### PR DESCRIPTION
Wheatley's Composition feature needs a bit of polish before launch, but we want to get Wheatley out to people soon. We're temporarily disabling the Rowgen selector (making the composition feature inaccessible); on a future release we'll re-enable this.