### PR TITLE
Temporarily remove Wheatley's composition feature

### DIFF
--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1280,7 +1280,7 @@ $(document).ready(function() {
 
         <div id="wheatley_row_gen_box">
             <!-- Wheatley row gen type toggle -->
-            <div class="btn-group btn-block btn-group-toggle">
+            <div class="d-none btn-group btn-block btn-group-toggle">
                 <label class="btn btn-outline-primary"
                        style="border-bottom-left-radius: 0;"
                        :class="{active: row_gen_panel == 'method',

--- a/app/static/sass/ringing_room.scss
+++ b/app/static/sass/ringing_room.scss
@@ -349,9 +349,10 @@ input[type=range]::slider-thumb {
 }
 
 #wheatley_row_gen_box_inner {
-    padding: 5px; 
-    border: 1px solid;
-    border-top: none;
+    // Uncomment to re-add rowgen selector
+    // padding: 5px; 
+    // border: 1px solid;
+    // border-top: none;
     border-bottom-right-radius: 0.25rem;
     border-bottom-left-radius: 0.25rem;
 }

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -105,11 +105,15 @@ is now available directly inside Ringing Room, without any installation.</p>
 </ol>
 <p>To ring something with Wheatley, assign Wheatley to any bells that you need filled. You can use the "Fill In" button in the Wheatley box to quickly assign all unassigned bells to Wheatley.</p>
 
-<p>Now, you need to tell Wheatley what you want to ring.  Wheatley can either ring a method
-(responding to user calls), or a composition from <a href="https://complib.org/">Composition
-Library</a> (calling any calls needed).  These correspond to the two tabs in the Wheatley box.</p>
+<p>Now, you need to tell Wheatley what you want to ring. Wheatley can ring any method you want, and will respond to any calls made through Ringing Room via the hotkeys while ringing.</p>
 
-<h5>Ringing a Method with Wheatley</h5>
+<!-- Wheatley can either ring a method -->
+<!-- (responding to user calls), or a composition from <a href="https://complib.org/">Composition -->
+<!-- Library</a> (calling any calls needed).  These correspond to the two tabs in the Wheatley box.</p> -->
+
+<!-- <h5>Ringing a Method with Wheatley</h5> -->
+
+<p>To start ringing a method with Wheatley:</p>
 
 <ol>
     <li>Click on the "Methods" tab in the Wheatley box.</li>
@@ -122,22 +126,20 @@ Library</a> (calling any calls needed).  These correspond to the two tabs in the
         <code>Look To</code> is called.</li>
 </ol>
 
-Wheatley will respond to any calls made through Ringing Room (i.e. via the hotkeys) while ringing.
+<!-- <h5>Ringing a Composition with Wheatley</h5> -->
 
-<h5>Ringing a Composition with Wheatley</h5>
-
-<ol>
-    <li>Find the composition you want to ring in <a href="https://complib.org/">CompLib</a>.
-        In order for Wheatley to find the exact composition, you need to get the composition's ID.
-        This is a number (usually 5 digits), which can be found at the end of the URL of the
-        composition or in the 'Library Details' section.</li>
-    <li>Click on the "Composition" tab in the Wheatley box.</li>
-    <li>Click in the text box that says "Public CompLib URL".</li>
-    <li>Type in the ID of the composition you want, and press enter.</li>
-    <li>If everything worked out, the first line of the Wheatley box should say <i>"After 'Look To',
-        Wheatley will ring &lt;your composition name&gt;"</i>, and Wheatley will ring and call that
-        composition after <code>Look To</code> is called.</li>
-</ol>
+<!-- <ol> -->
+<!--     <li>Find the composition you want to ring in <a href="https://complib.org/">CompLib</a>. -->
+<!--         In order for Wheatley to find the exact composition, you need to get the composition's ID. -->
+<!--         This is a number (usually 5 digits), which can be found at the end of the URL of the -->
+<!--         composition or in the 'Library Details' section.</li> -->
+<!--     <li>Click on the "Composition" tab in the Wheatley box.</li> -->
+<!--     <li>Click in the text box that says "Public CompLib URL".</li> -->
+<!--     <li>Type in the ID of the composition you want, and press enter.</li> -->
+<!--     <li>If everything worked out, the first line of the Wheatley box should say <i>"After 'Look To', -->
+<!--         Wheatley will ring &lt;your composition name&gt;"</i>, and Wheatley will ring and call that -->
+<!--         composition after <code>Look To</code> is called.</li> -->
+<!-- </ol> -->
 
 <h4><a id="managing_towers"></a>Managing your towers</h4>
 


### PR DESCRIPTION
Wheatley's composition feature needs a bit of polish before launch. This PR temporarily disables the RowGen selector in the Wheatley box, making the composition feature inaccessible, and updates the help to match. This will be squashed-and-merged so that it can be easily reverted when we're ready to launch the composition feature.