### PR TITLE
Kick users

### DIFF
--- a/app/listeners.py
+++ b/app/listeners.py
@@ -4,7 +4,7 @@ from flask_login import current_user
 from app import app
 from config import Config
 from app.extensions import socketio, log
-from app.models import Tower, towers
+from app.models import Tower, towers, User
 from app.auth import token_login
 from app.email import send_email
 import random
@@ -186,6 +186,24 @@ def on_user_left(json):
         emit('s_host_mode',{'tower_id': tower_id,
                             'new_mode': False},
              broadcast=True, include_self=True, room=tower_id)
+
+@socketio.on('c_kick_user')
+@token_login
+def on_kick_user(json):
+    log('c_kick_user', json)
+    tower_id = json['tower_id']
+    tower = towers[tower_id]
+    user_id = json['user_id']
+    user = User.query.get(user_id)
+    if user is None:
+        return
+    tower.remove_user(user_id)
+    emit('s_user_left', {'user_id': user_id,
+                         'username': user.username,
+                         'kicked': True},
+         broadcast=True, include_self=True, room=tower_id)
+
+
 
 # # A user disconnected (via timeout)
 # @socketio.on('disconnect')

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1673,6 +1673,7 @@ $(document).ready(function () {
 
         data: function () {
             return {
+                kicking: false,
                 circled_digits: [
                     "①",
                     "②",
@@ -1758,6 +1759,12 @@ $(document).ready(function () {
             },
 
             kick_user: function(){
+                if (!this.kicking) {
+                    console.log('marking kicking');
+                    this.kicking = true;
+                    setTimeout(()=>this.kicking = false, 2000);
+                    return
+                }
                 socketio.emit('c_kick_user', { tower_id: cur_tower_id,
                                                user_id: this.user_id });
             }
@@ -1778,7 +1785,9 @@ $(document).ready(function () {
             v-if="kickable"
             @click="kick_user"
             >
-            <i class="far fa-window-close"></i>
+            <small style="vertical-align: text-bottom;" v-if="kicking">Sure?</small>
+            <i v-if="!kicking" class="far fa-window-close"></i>
+            <i v-if="kicking" style="color: #b2276e;" class="fas fa-window-close"></i>
         </span>
 </li>
 `,

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1737,6 +1737,7 @@ $(document).ready(function () {
             },
 
             kickable: function() {
+                if (this.assignment_mode_active) return false;
                 if (this.$root.$refs.controls.lock_controls) return false;
                 if (!this.$root.$refs.controls.host_mode) return false;
                 if (this.user_id === parseInt(window.tower_parameters.cur_user_id)) return false;


### PR DESCRIPTION
This enables the ability to kick users out of towers. (The main use case is for when someone gets "trapped" in a tower.) Only hosts make kick users out, and host mode must be enabled for them to do so; you can't kick yourself or Wheatley out of the tower, and you can't kick users out in assignment mode (to prevent misclicks).