### PR TITLE
Make survey open in new tab

### DIFF
--- a/app/templates/ringing_room.html
+++ b/app/templates/ringing_room.html
@@ -116,7 +116,7 @@
     </div>
 
     <div class="alert alert-primary fixed-top ml-auto mx-5" style="width: max-content;" role="alert">
-        <a href="{{url_for('survey')}}" class="stretched-link">Take our survey!</a>
+        <a href="{{url_for('survey')}}" target="_blank" class="stretched-link">Take our survey!</a>
     </div>
 </body>
 


### PR DESCRIPTION
Currently people are randomly leaving towers to go check out the survey, which I think is quite funny but should probably be fixed.