### PR TITLE
Don't autoassign when no supported controllers

### DIFF
--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -681,10 +681,10 @@ $(document).ready(function () {
         },
 
         template: `
-<h2 v-show="visible" 
-    v-if="!window.tower_parameters.listen_link 
+<h2 v-show="visible"
+    v-if="!window.tower_parameters.listen_link
           && !window.tower_parameters.anonymous_user
-          && !controller_active" 
+          && !controller_active"
           id='focus_display'>
     Click anywhere in Ringing Room to resume ringing.
 </h2>
@@ -1876,7 +1876,7 @@ $(document).ready(function () {
              clickable: assignment_mode_active}"
     @click="select_user"
     >
-    <img v-if="badge" 
+    <img v-if="badge"
          v-bind:class="{invert_colors: selected}"
          class="mt-n1 mr-1" width=30 height=30 v-bind:src="'/static/images/' + badge"/>
     [[ username ]]
@@ -2235,7 +2235,7 @@ $(document).ready(function () {
             },
 
             autoassign_controllers: function () {
-                if (this.controller_index.length > 2) {
+                if (this.controller_index.length === 0 || this.controller_index.length > 2) {
                     // Do nothing: autoassignment isn't well defined with more than two controllers
                     return;
                 }
@@ -2491,7 +2491,7 @@ $(document).ready(function () {
                     // console.log('turning on keypress listening')
                     _bind_hotkeys(bell_circle);
                 }
-                
+
                 $("*").focus(() => {
                     if (document.activeElement.classList.contains("autoblur")) {
                         document.activeElement.blur();


### PR DESCRIPTION
Fixes
```
TypeError: Cannot set property 'bell' of undefined
    at autoassign_controllers (rr.37e0614e.js:2186)
    at assigned_bells (rr.37e0614e.js:2285)
    at fn.get (vue.min.js:6)
    at fn.evaluate (vue.min.js:6)
    at a.assigned_bells (vue.min.js:6)
    ...
```