### PR TITLE
Detect when no supported controllers

### DIFF
--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -2286,6 +2286,8 @@ $(document).ready(function () {
                     }
                     this.controller_list[myCont] = contObj;
                 }
+
+                this.has_controller = this.controller_index.length > 0
             },
 
             toggle_controllers: function () {


### PR DESCRIPTION
Makes behaviour the same as when no controllers plugged in
1) Show no focus box
2) Hides the controller box