### PR TITLE
Align handbell labels at top

### DIFF
--- a/app/static/sass/ringing_room.scss
+++ b/app/static/sass/ringing_room.scss
@@ -185,7 +185,7 @@ input[type=range]::slider-thumb {
 }
 
 
-/* Bells */ 
+/* Bells */
 
 .bell_circle_col {
     z-index: 2;
@@ -341,6 +341,10 @@ input[type=range]::slider-thumb {
                 transform: scaleX(-1);
             }
         }
+
+        &.top {
+            align-items: flex-start;
+        }
     }
 
     &.cowbell {
@@ -414,7 +418,7 @@ input[type=range]::slider-thumb {
 
 #wheatley_row_gen_box_inner {
     // Uncomment to re-add rowgen selector
-    // padding: 5px; 
+    // padding: 5px;
     // border: 1px solid;
     // border-top: none;
     border-bottom-right-radius: 0.25rem;
@@ -473,8 +477,8 @@ input[type=range]::slider-thumb {
 /* On larger screens, permanently open the menu */
 @include media-breakpoint-up(lg){
     html { min-height:100%; }
-    .collapse.tower_controls, .collapse.tower_controls:not(.show) { 
-        display: flex; 
+    .collapse.tower_controls, .collapse.tower_controls:not(.show) {
+        display: flex;
         flex-grow: 1;
     }
     .sidebar_col {


### PR DESCRIPTION
Stops bells overlapping with labels. Consistent with towerbell circle.
Fixe #247

![image](https://user-images.githubusercontent.com/10487726/116300272-9d3ebe80-a796-11eb-9a32-5f7724f14205.png)
