### PR TITLE
Wheatley box tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,10 +245,11 @@ for keeping Wheatley in sync with the rest of Ringing Room.  Some of these signa
 #### The 'Settings' type
 The _Settings_ type is an object with 0 or more of the following properties:
 ```
-sensitivity   : float; 0 <= x <= 1
-use_up_down_in: Bool
-stop_at_rounds: Bool
-peal_speed    : int; x >= 0
+sensitivity             : float; 0 <= x <= 1 (currently unused)
+use_up_down_in          : Bool
+stop_at_rounds          : Bool
+peal_speed              : int; x >= 0
+fixed_striking_interval : Bool (ignored by Wheatley, changes `peal_speed` when the tower size is changed)
 ```
 
 #### The 'RowGen' type

--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ What follows is a incomplete list of events — these should be only the events 
 | `s_bad_token`            | (variable)                                                               | The user send a bad bearer token. (Payload repeats whatever triggered this response.) |
 
 ### Wheatley
-The changes to Wheatley have added a number of extra SocketIO signals, used for keeping Wheatley in sync
-with the rest of Ringing Room.  Some of these signals have custom types (`RowGen` and `Signals`,
-which are described in detail below the table.
+The integration of Wheatley into Ringing Room have added a number of extra SocketIO signals, used
+for keeping Wheatley in sync with the rest of Ringing Room.  Some of these signals have custom types
+(`RowGen` and `Signals`, which are described in detail below the table.
 
 | Event | Payload | Description |
 | --- | --- | --- |

--- a/app/routes.py
+++ b/app/routes.py
@@ -83,7 +83,7 @@ def tower(tower_id, decorator=None):
     # Pass in both the tower and the user_name
     return render_template('ringing_room.html',
                             tower = tower,
-                            user_id = '' if current_user.is_anonymous else current_user.id,
+                            user_id = 0 if current_user.is_anonymous else current_user.id,
                             user_name = '' if current_user.is_anonymous else current_user.username,
                             user_email = '' if current_user.is_anonymous else current_user.email,
                             user_badge = '' if current_user.is_anonymous else current_user.badge,

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1526,7 +1526,7 @@ $(document).ready(function () {
                :disabled="settings_panel_disabled"
                />
         <label for="up_down_in" title="If checked, Wheatley will go into changes after two rounds.">
-            Ring up-down-in
+            Whole pull and off
         </label>
         <br/>
 

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -79,7 +79,7 @@ socketio.on("s_bell_rung", function (msg, cb) {
 // A bell was silently swapped between strokes
 socketio.on("s_silent_swap", function (msg, cb) {
     // console.log('silent swap', msg);
-    bell_circle.$refs.bells[parseInt(msg.who_swapped)-1].set_state_silently(msg.new_bell_state);
+    bell_circle.$refs.bells[parseInt(msg.who_swapped) - 1].set_state_silently(msg.new_bell_state);
 });
 
 // Userlist was set
@@ -105,9 +105,9 @@ socketio.on("s_user_entered", function (msg, cb) {
 socketio.on("s_user_left", function (msg, cb) {
     // console.log(msg.username + ' left')
     // It's possible that we'll receive this when we've just been kicked. If so, redirect
-    console.log(msg)
+    console.log(msg);
     if (msg.kicked && msg.user_id === parseInt(window.tower_parameters.cur_user_id)) {
-        window.location.href = '/';
+        window.location.href = "/";
     }
     bell_circle.$refs.users.remove_user(msg);
     bell_circle.$refs.bells.forEach((bell, index) => {
@@ -455,7 +455,7 @@ $(document).ready(function () {
                 });
             },
 
-            assign_user_by_id: function(id) {
+            assign_user_by_id: function (id) {
                 if (window.tower_parameters.anonymous_user) {
                     return;
                 } // don't assign if not logged in
@@ -657,7 +657,7 @@ $(document).ready(function () {
         },
 
         computed: {
-            controller_active: function(){
+            controller_active: function () {
                 const controllers = this.$root.$refs.controllers;
                 return controllers.has_controller;
             },
@@ -1073,7 +1073,7 @@ $(document).ready(function () {
             peal_speed: function () {
                 // Clamp the peal speed to a reasonable range
                 const last_peal_speed = this.peal_speed;
-                this.peal_speed = Math.max(Math.min(last_peal_speed, 300), 60);
+                this.peal_speed = Math.max(Math.min(last_peal_speed, 8 * 60), 60);
                 // Send an update to the server if the user **actually** changed the value
                 if (last_peal_speed != this.peal_speed) {
                 }
@@ -1837,14 +1837,14 @@ $(document).ready(function () {
                 return this.$root.$refs.users.assignment_mode;
             },
 
-            kickable: function() {
+            kickable: function () {
                 if (this.assignment_mode_active) return false;
                 if (this.$root.$refs.controls.lock_controls) return false;
                 if (!window.tower_parameters.host_permissions) return false;
                 if (this.user_id === parseInt(window.tower_parameters.cur_user_id)) return false;
                 if (this.user_id === -1) return false;
                 return true;
-            }
+            },
         },
 
         methods: {
@@ -1858,16 +1858,15 @@ $(document).ready(function () {
                 this.$root.$refs.users.selected_user = this.user_id;
             },
 
-            kick_user: function(){
+            kick_user: function () {
                 if (!this.kicking) {
-                    console.log('marking kicking');
+                    console.log("marking kicking");
                     this.kicking = true;
-                    setTimeout(()=>this.kicking = false, 2000);
-                    return
+                    setTimeout(() => (this.kicking = false), 2000);
+                    return;
                 }
-                socketio.emit('c_kick_user', { tower_id: cur_tower_id,
-                                               user_id: this.user_id });
-            }
+                socketio.emit("c_kick_user", { tower_id: cur_tower_id, user_id: this.user_id });
+            },
         },
 
         template: `
@@ -2113,10 +2112,14 @@ $(document).ready(function () {
                 back_strike: window.user_settings.controller_backstroke,
                 debounce: window.user_settings.controller_debounce,
                 buttons: {
-                    left: [ window.user_settings.controller_left_left,
-                            window.user_settings.controller_left_right],
-                    right:[ window.user_settings.controller_right_left,
-                            window.user_settings.controller_right_right]
+                    left: [
+                        window.user_settings.controller_left_left,
+                        window.user_settings.controller_left_right,
+                    ],
+                    right: [
+                        window.user_settings.controller_right_left,
+                        window.user_settings.controller_right_right,
+                    ],
                 },
                 next_ring: 0,
                 has_controller: false,
@@ -2147,9 +2150,9 @@ $(document).ready(function () {
                     "⑮",
                     "⑯",
                 ],
-                debounce_func: function(cont) {
+                debounce_func: function (cont) {
                     console.log("calling debounce with", cont);
-                    cont.debounced = false
+                    cont.debounced = false;
                 },
             };
         },
@@ -2176,20 +2179,18 @@ $(document).ready(function () {
                         try {
                             if (Math.max.apply(null, cont.axes.map(Math.abs)) > 0) {
                                 var swing = cont.axes[2] * 2048;
-                                if (
-                                    swing >= this.hand_strike &&
-                                    curCont.at_hand
-                                ) {
+                                if (swing >= this.hand_strike && curCont.at_hand) {
                                     curCont.at_hand = !curCont.at_hand;
                                     this.assign_cont_to_bell(curCont);
                                     if (curCont.bell) {
                                         bell_circle.pull_rope(curCont.bell);
                                         curCont.debounced = true;
                                         setTimeout(
-                                            function(i){
+                                            function (i) {
                                                 i.debounced = false;
                                             }.bind(this, curCont),
-                                            this.debounce);
+                                            this.debounce
+                                        );
                                     }
                                 }
                                 if (
@@ -2203,10 +2204,11 @@ $(document).ready(function () {
                                         bell_circle.pull_rope(curCont.bell);
                                         curCont.debounced = true;
                                         setTimeout(
-                                            function(i){
+                                            function (i) {
                                                 i.debounced = false;
                                             }.bind(this, curCont),
-                                            this.debounce);
+                                            this.debounce
+                                        );
                                     }
                                 }
                             }
@@ -2222,12 +2224,12 @@ $(document).ready(function () {
                                     // Any bell not part of a sensible handbell pair should be able to call bob & single
                                     //
 
-                                    var left_hand = this.assigned_bells ?
-                                        curCont.bell === bell_circle.find_rope_by_hand(LEFT_HAND) :
-                                        (curCont.bell % 2 == 0 &&
-                                            this.assigned_bells.includes(curCont.bell - 1));
+                                    var left_hand = this.assigned_bells
+                                        ? curCont.bell === bell_circle.find_rope_by_hand(LEFT_HAND)
+                                        : curCont.bell % 2 == 0 &&
+                                          this.assigned_bells.includes(curCont.bell - 1);
 
-                                    if (left_hand){
+                                    if (left_hand) {
                                         this.buttons.left[i](this.$root);
                                     } else {
                                         this.buttons.right[i](this.$root);
@@ -2302,7 +2304,7 @@ $(document).ready(function () {
                     this.controller_list[myCont] = contObj;
                 }
 
-                this.has_controller = this.controller_index.length > 0
+                this.has_controller = this.controller_index.length > 0;
             },
 
             toggle_controllers: function () {
@@ -2516,7 +2518,6 @@ $(document).ready(function () {
                         document.activeElement.blur();
                     }
                 });
-
             });
         },
 

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -738,7 +738,6 @@ $(document).ready(function () {
                 // changed the tower size creates a new `c_wheatley_setting` signal for the peal
                 // speed - this way, the server isn't inundated with identical settings changes.
                 const old_size = this.number_of_bells;
-                console.log(`${old_size} -> ${size}`);
                 bell_circle.$refs.wheatley.on_tower_size_change(old_size, size);
 
                 // console.log('setting tower size to ' + size);
@@ -806,13 +805,11 @@ $(document).ready(function () {
                        disabled: lock_controls}"
                        @click="set_tower_size(size)"
                        >
-                    <!--
                     <input type="radio"
                            class="autoblur"
                            name="size"
                            :value="size"
                            />
-                    -->
                     [[ size ]]
                 </label>
             </div>
@@ -974,6 +971,10 @@ $(document).ready(function () {
                     url: "Double_Norwich_Court_Bob_Major",
                 },
 
+                // The tower size that Wheatley think the tower has been switched to.  We need to
+                // track this because the addition of autoblur causes two `c_size_change` signals to
+                // be generated (which would otherwise cause the peal speed to change twice).
+                last_tower_size: undefined,
                 // Peal speed has 3 values - two which are bound to the input fields, and one
                 // combined value that is the 'ground truth'.  This guaruntees that the display
                 // always represents the correct peal speed in the correct way (i.e. such that
@@ -1155,6 +1156,11 @@ $(document).ready(function () {
             // Updates the peal speed if the tower size changes, in order to keep the intervals
             // between bells as consistent as possible
             on_tower_size_change: function (old_size, new_size) {
+                if (this.last_tower_size != undefined && new_size == this.last_tower_size) {
+                    return; // Don't update the peal size if we've already received this size change
+                }
+                this.last_tower_size = new_size;
+
                 if (!this.fixed_striking_interval) {
                     return; // Don't update peal speed unless `fixed_striking_interval` is set
                 }

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -1155,6 +1155,9 @@ $(document).ready(function () {
             // Updates the peal speed if the tower size changes, in order to keep the intervals
             // between bells as consistent as possible
             on_tower_size_change: function (old_size, new_size) {
+                if (!this.fixed_striking_interval) {
+                    return; // Don't update peal speed unless `fixed_striking_interval` is set
+                }
                 // Compute the number of 'strikes' contained within a handstroke/backstroke pair of
                 // rows (the `+ 1` is the handstroke gap).  The ratio between these is the ratio
                 // that the peal speed must be adjusted.

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -70,20 +70,20 @@ window.user_parameters = {
 ////////////////////////
 
 // A bell was rung
-socketio.on("s_bell_rung", function (msg, cb) {
+socketio.on("s_bell_rung", function (msg) {
     // console.log('Received event: ' + msg.global_bell_state + msg.who_rang);
     // if(msg.disagree) {}
     bell_circle.ring_bell(msg.who_rang);
 });
 
 // A bell was silently swapped between strokes
-socketio.on("s_silent_swap", function (msg, cb) {
+socketio.on("s_silent_swap", function (msg) {
     // console.log('silent swap', msg);
     bell_circle.$refs.bells[parseInt(msg.who_swapped) - 1].set_state_silently(msg.new_bell_state);
 });
 
 // Userlist was set
-socketio.on("s_set_userlist", function (msg, cb) {
+socketio.on("s_set_userlist", function (msg) {
     // console.log('s_set_userlist: ',  msg.user_list);
     bell_circle.$refs.users.user_names = msg.user_list;
     msg.user_list.forEach((user, index) => {
@@ -96,13 +96,13 @@ socketio.on("s_set_userlist", function (msg, cb) {
 });
 
 // User entered the room
-socketio.on("s_user_entered", function (msg, cb) {
+socketio.on("s_user_entered", function (msg) {
     // console.log(msg.username + ' entered')
     bell_circle.$refs.users.add_user(msg);
 });
 
 // User left the room
-socketio.on("s_user_left", function (msg, cb) {
+socketio.on("s_user_left", function (msg) {
     // console.log(msg.username + ' left')
     // It's possible that we'll receive this when we've just been kicked. If so, redirect
     console.log(msg);
@@ -118,13 +118,13 @@ socketio.on("s_user_left", function (msg, cb) {
 });
 
 // Number of observers changed
-socketio.on("s_set_observers", function (msg, cb) {
+socketio.on("s_set_observers", function (msg) {
     // console.log('observers: ' + msg.observers);
     bell_circle.$refs.users.observers = msg.observers;
 });
 
 // User was assigned to a bell
-socketio.on("s_assign_user", function (msg, cb) {
+socketio.on("s_assign_user", function (msg) {
     // console.log('Received user assignment: ' + msg.bell + ' ' + msg.user);
     try {
         // This stochastically very error-prone:
@@ -146,13 +146,13 @@ socketio.on("s_assign_user", function (msg, cb) {
 });
 
 // A call was made
-socketio.on("s_call", function (msg, cb) {
+socketio.on("s_call", function (msg) {
     // console.log('Received call: ' + msg.call);
     bell_circle.$refs.display.make_call(msg.call);
 });
 
 // The server told us the number of bells in the tower
-socketio.on("s_size_change", function (msg, cb) {
+socketio.on("s_size_change", function (msg) {
     var new_size = msg.size;
     bell_circle.number_of_bells = new_size;
     // The user may already be assigned to something, so rotate
@@ -163,7 +163,7 @@ socketio.on("s_size_change", function (msg, cb) {
 });
 
 // The server sent us the global state; set all bells accordingly
-socketio.on("s_global_state", function (msg, cb) {
+socketio.on("s_global_state", function (msg) {
     var gstate = msg.global_bell_state;
     for (var i = 0; i < gstate.length; i++) {
         try {
@@ -181,7 +181,7 @@ socketio.on("s_global_state", function (msg, cb) {
 });
 
 // The server told us whether to use handbells or towerbells
-socketio.on("s_audio_change", function (msg, cb) {
+socketio.on("s_audio_change", function (msg) {
     // console.log('changing audio to: ' + msg.new_audio);
     bell_circle.$refs.controls.audio_type = msg.new_audio;
     bell_circle.audio = audio_types[msg.new_audio];
@@ -192,7 +192,7 @@ socketio.on("s_audio_change", function (msg, cb) {
 });
 
 // A chat message was received
-socketio.on("s_msg_sent", function (msg, cb) {
+socketio.on("s_msg_sent", function (msg) {
     bell_circle.$refs.chatbox.messages.push(msg);
     if (msg.email != window.tower_parameters.cur_user_email && !$("#chat_input_box").is(":focus")) {
         bell_circle.unread_messages++;
@@ -231,7 +231,7 @@ if (!window.tower_parameters.listen_link) {
 }
 
 // Host mode was changed
-socketio.on("s_host_mode", function (msg, cb) {
+socketio.on("s_host_mode", function (msg) {
     bell_circle.$refs.controls.host_mode = msg.new_mode;
 });
 
@@ -404,12 +404,11 @@ $(document).ready(function () {
                     stroke: this.stroke,
                     tower_id: cur_tower_id,
                 });
-                var report =
-                    "Bell " +
-                    this.number +
-                    " will ring a " +
-                    (this.stroke ? "handstroke" : "backstroke");
-                // console.log(report);
+                /*
+                console.log(
+                    `Bell ${this.number} will ring at ${this.stroke ? "handstroke" : "backstroke"}`
+                );
+                */
             },
 
             // Ringing event received; now ring the bell
@@ -431,12 +430,11 @@ $(document).ready(function () {
                     // console.log(audio_type + ' ' + this.number_of_bells);
                 }
                 audio_obj.play(bell_mappings[audio_type][this.number_of_bells][this.number - 1]);
-                var report =
-                    "Bell " +
-                    this.number +
-                    " rang a " +
-                    (this.stroke ? "backstroke" : "handstroke");
-                // console.log(report);
+                /*
+                console.log(
+                    `Bell ${this.number} rang a ${this.stroke ? "handstroke" : "backstroke"}`
+                );
+                */
             },
 
             // global_state received; set the bell to the correct stroke
@@ -627,8 +625,7 @@ $(document).ready(function () {
             // a call was received from the server; display it and play audio
             make_call: function (call) {
                 this.display_message(call, 2000);
-                if (call.indexOf("sorry") != -1 ||
-                    call.indexOf("Sorry") != -1) {
+                if (call.indexOf("sorry") != -1 || call.indexOf("Sorry") != -1) {
                     calls.play("SORRY");
                 } else if (call in call_types) {
                     calls.play(call_types[call]);
@@ -735,8 +732,8 @@ $(document).ready(function () {
             // the user clicked a tower-size button
             set_tower_size: function (size) {
                 if (window.tower_parameters.anonymous_user) {
-                    return;
-                } // don't do anything if not logged in
+                    return; // don't do anything if not logged in
+                }
                 // console.log('setting tower size to ' + size);
                 socketio.emit("c_size_change", {
                     new_size: size,
@@ -967,6 +964,7 @@ $(document).ready(function () {
                     title: "Double Norwich Court Bob Major",
                     url: "Double_Norwich_Court_Bob_Major",
                 },
+
                 // Peal speed has 3 values - two which are bound to the input fields, and one
                 // combined value that is the 'ground truth'.  This guaruntees that the display
                 // always represents the correct peal speed in the correct way (i.e. such that
@@ -978,12 +976,14 @@ $(document).ready(function () {
                 //   - Uses the new value to set `peal_speed_mins` and `peal_speed_hours` to a valid
                 //     representation
                 //   - Sends a socketio signal with the new peal speed
-                peal_speed_hours: 2,
-                peal_speed_mins: 55,
+                peal_speed_hours: "2", // (string): Bound to the value of 'hours' UI box
+                peal_speed_mins: "55", // (string): Bound to the value of 'mins' UI box
+                // Number value of the total mins of the peal speed.  Sent over SocketIO and
+                // computed with `peal_speed_hours * 60 + peal_speed_mins`.
                 peal_speed: 175,
 
                 // Row-gen panel configuration
-                row_gen_panel: "method",
+                row_gen_panel: "method", // "method" | "composition": Which tab is open
 
                 method_name: "",
                 autocomplete_options: [],
@@ -1070,13 +1070,10 @@ $(document).ready(function () {
                 }
             },
 
+            // Update the UI whenever the backing `peal_speed` value changes
             peal_speed: function () {
-                // Clamp the peal speed to a reasonable range
-                const last_peal_speed = this.peal_speed;
-                this.peal_speed = Math.max(Math.min(last_peal_speed, 8 * 60), 60);
-                // Send an update to the server if the user **actually** changed the value
-                if (last_peal_speed != this.peal_speed) {
-                }
+                // Clamp the peal speed to a max of 8 hours
+                this.peal_speed = Math.max(Math.min(this.peal_speed, 8 * 60), 60);
                 // Update the controls to the correct representation of the speed
                 this.peal_speed_mins = (this.peal_speed % 60).toString();
                 this.peal_speed_hours = Math.floor(this.peal_speed / 60).toString();
@@ -1085,6 +1082,14 @@ $(document).ready(function () {
 
         methods: {
             /* METHODS CALLED WHEN THE USER CHANGES THE CONTROLS */
+
+            // NOTE: These are called specifically when a **user** changes the controls, not simply
+            // when the variables change (i.e. these aren't 'watcher' callbacks for the underlying
+            // variable).  If these _where_ watchers, then each socket signal received would trigger
+            // the callback, thus sending _another_ socket signal.  This causes an infinite echo
+            // chamber of socket signals, which would effectively immobilise the controls, as well
+            // as causing enormous stress to the Ringing Room server.
+
             on_change_sensitivity: function () {
                 socketio.emit("c_wheatley_setting", {
                     tower_id: cur_tower_id,
@@ -1121,8 +1126,8 @@ $(document).ready(function () {
                 });
             },
 
+            // Assign all unassigned bells to Wheatley
             fill_bells: function () {
-                // Assign all unassigned bells to Wheatley
                 for (const bell of bell_circle.$refs.bells) {
                     if (!bell.assigned_user) {
                         // -1 is Wheatley's user ID (see USER_ID in app/wheatley.py)
@@ -2512,9 +2517,7 @@ $(document).ready(function () {
                 }
 
                 $("*").focus(() => {
-                    console.log(document.activeElement);
                     if (document.activeElement.classList.contains("autoblur")) {
-                        console.log("autoblur triggered")
                         document.activeElement.blur();
                     }
                 });


### PR DESCRIPTION
This PR makes the following quality-of-life improvements to the Wheatley box:
- The max peal speed is now 8 hours
- `Ring up-down-in` now says `Whole pull and off` (by [popular vote](https://www.facebook.com/groups/bellringers/posts/10159412452400859))
- There is now an option to automatically adjust the peal speed when changing between different tower sizes

There's an open question here: does the 'Fixed striking interval' checkbox even need to exist?  I honestly can't think of a situation where the old behaviour would be preferable, and at the end of the day you can still adjust the peal speed to your delectation after changing the tower size.  @lelandpaul, @BrynMarieR what do you think?

Either way, I'd like to rebase the commits before merging - I've set up the commit history so that removing the checkbox is a simple rebase operation, but that makes the commit history less intuitive.