### PR TITLE
Mouse Mode

### DIFF
--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -3100,7 +3100,7 @@ $(document).ready(function () {
          @click="pull_rope_by_hand('right')"
          >
         <p id="overlay_warning">
-            Accessibility mode enabled.<br/>
+            Mouse mode enabled.<br/>
             Click anywhere to ring.
             Press <b>[[ user_settings.accessibility_overlay_hotkey ]]</b> to deactivate.
         </p>

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -3100,7 +3100,7 @@ $(document).ready(function () {
          @click="pull_rope_by_hand('right')"
          >
         <p id="overlay_warning">
-            Mouse mode enabled.<br/>
+            Mouse Mode enabled.<br/>
             Click anywhere to ring.
             Press <b>[[ user_settings.accessibility_overlay_hotkey ]]</b> to deactivate.
         </p>

--- a/app/static/ringing_room.js
+++ b/app/static/ringing_room.js
@@ -2773,6 +2773,7 @@ $(document).ready(function () {
             host_mode: window.tower_parameters.host_mode,
             bookmarked: window.tower_parameters.bookmarked,
             anticlockwise: window.tower_parameters.anticlockwise,
+            accessibility_overlay: false,
         },
 
         watch: {
@@ -3085,11 +3086,26 @@ $(document).ready(function () {
             leave_tower: function () {
                 leave_room();
             },
+
+            toggle_accessibility_overlay: function () {
+                this.accessibility_overlay = !this.accessibility_overlay;
+            },
         },
 
         template: `
 <div id="bell_circle_wrapper">
-    <div class="row flex-lg-nowrap" id="sidebar_col_row">
+    <div v-if="accessibility_overlay" 
+         id="accessibility_overlay"
+         class="text-right clickable_div"
+         @click="pull_rope_by_hand('right')"
+         >
+        <p id="overlay_warning">
+            Accessibility mode enabled.<br/>
+            Click anywhere to ring.
+            Press <b>[[ user_settings.accessibility_overlay_hotkey ]]</b> to deactivate.
+        </p>
+    </div>
+    <div class="row flex-lg-nowrap" id="sidebar_col_row" :class="{disabled: accessibility_overlay}">
         <div class="col-12 col-lg-4 sidebar_col">
             <!-- sidebar col -->
             <div class="tower_header">

--- a/app/static/sass/ringing_room.scss
+++ b/app/static/sass/ringing_room.scss
@@ -470,6 +470,27 @@ input[type="range"]::slider-thumb {
     cursor: auto;
 }
 
+.disabled .sidebar_col {
+    opacity: 0.5;
+}
+
+#accessibility_overlay {
+    width: 100%;
+    height: 100%;
+    position: fixed;
+    z-index: 10;
+    left: 0;
+    top: 0;
+    overflow-x: hidden; /* Disable horizontal scroll */
+}
+
+#overlay_warning {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    padding-right: 1.5rem;
+}
+
 /* Scary mixin land */
 
 /* On larger screens, permanently open the menu */

--- a/app/static/user_settings_form.js
+++ b/app/static/user_settings_form.js
@@ -80,7 +80,7 @@ $(document).ready(function () {
             cat: "bell",
             desc: "",
         },
-        "overlay": { id: 63, name: "Toggle mouse mode", cat: "acc", desc: "" },
+        "overlay": { id: 63, name: "Toggle Mouse Mode", cat: "acc", desc: "" },
     };
 
     Vue.component("remove_button", {

--- a/app/static/user_settings_form.js
+++ b/app/static/user_settings_form.js
@@ -80,7 +80,7 @@ $(document).ready(function () {
             cat: "bell",
             desc: "",
         },
-        "overlay": { id: 63, name: "Toggle accessibility overlay", cat: "adv", desc: "" },
+        "overlay": { id: 63, name: "Toggle mouse mode", cat: "acc", desc: "" },
     };
 
     Vue.component("remove_button", {
@@ -178,6 +178,9 @@ $(document).ready(function () {
             },
             call_functions: function () {
                 return this._filter_functions("call");
+            },
+            acc_functions: function() {
+                return this._filter_functions("acc");
             },
             adv_functions: function () {
                 return this._filter_functions("adv");
@@ -312,6 +315,16 @@ $(document).ready(function () {
             <div id="keybinds_calls">
                 <h3>Calls</h3>
                 <function_row v-for="func in call_functions"
+                    v-bind:func="func"
+                    v-bind:keys="rows[func]"
+                    @remove="(k)=>unbind(k)"
+                    @add="(f,k)=>bind(f,k)"
+                    @reset="(f)=>reset(f)"
+                    ></function_row>
+            </div>
+            <div id="keybinds_accessibility">
+                <h3>Accessibility</h3>
+                <function_row v-for="func in acc_functions"
                     v-bind:func="func"
                     v-bind:keys="rows[func]"
                     @remove="(k)=>unbind(k)"

--- a/app/static/user_settings_form.js
+++ b/app/static/user_settings_form.js
@@ -80,6 +80,7 @@ $(document).ready(function () {
             cat: "bell",
             desc: "",
         },
+        "overlay": { id: 63, name: "Toggle accessibility overlay", cat: "adv", desc: "" },
     };
 
     Vue.component("remove_button", {

--- a/app/templates/_parameter_bindings.html
+++ b/app/templates/_parameter_bindings.html
@@ -37,6 +37,7 @@
     {% if not listen_link %}
 
     window.user_settings = {
+            accessibility_overlay_hotkey: "{{user_settings['keybindings']['overlay'][0]}}",
             controller_debounce: parseInt({{user_settings['controllers']['debounce']}}),
             controller_handstroke: parseInt({{user_settings['controllers']['handstroke']}}),
             controller_backstroke: parseInt({{user_settings['controllers']['backstroke']}}),
@@ -94,6 +95,9 @@
         Mousetrap.bind({{user_settings['keybindings']['rounds'] | safe}}, ()=>bell_obj.make_call("Rounds"));
         Mousetrap.bind({{user_settings['keybindings']['change'] | safe}}, ()=>bell_obj.make_call("Change method"));
         Mousetrap.bind({{user_settings['keybindings']['sorry'] | safe}}, ()=>bell_obj.make_call(window.tower_parameters.cur_user_name + " says sorry."));
+
+        // Accessibility overlay
+        Mousetrap.bind({{user_settings['keybindings']['overlay'] | safe}}, ()=>bell_obj.toggle_accessibility_overlay());
     }
 
     {% endif %}

--- a/app/templates/help.md
+++ b/app/templates/help.md
@@ -214,6 +214,7 @@ The **Keyboard** tab allows you to customize the keyboard hotkeys used to contro
 -   **Rounds**: Call "Rounds" (Defaults: `o`, `O`)
 -   **Change method**: Call "Change method" (Defaults: `c`, `C`)
 -   **Sorry**: Apologize (Defaults: `s`)
+- **Mouse Mode**: Enable a [mouse-only accessibility mode](#mouse-mode) (Defaults: none)
 -   **Ring bell 1–16**: (Advanced) Ring specific bell (Defaults: `1–9`, `0`, `-`, `=`, `q`, `w`, `e`, `r`)
 -   **Rotate to 1–16**: (Advanced) Rotate the circle so that a given bell is in the bottom-right (Defaults: `shift + 1–9`, `0`, `-`, `=`, `q`, `w`, `e`, `r`)
 -   **Catch hold of 1–16**: (Advanced) Assign yourself to the given bell. (Defaults: `ctrl + shift + 1-9`, `0`, `-`, `=`, `q`, `w`, `e`, `r` on Windows` , ``cmd + shift+ 1-9 `, `0`, `-`, `= ,q`, `e`, `r` on Mac.)
@@ -236,9 +237,14 @@ The controller buttons can be set to make calls or to silently flip the stroke o
 -   **Left bell**: Left button: `Stand`; right button: `Go`.
 -   **Right bell**: Left button: `Single`, right button: `Bob`.
 
+
 ## Additional features
 
 There are a few miscellaneous features that don't fit elsewhere.
+
+### Mouse Mode
+
+Mouse Mode is an accessibility feature that allows you to click anywhere on the screen to ring your bell, rather than needing to use a hotkey or click specifically on the rope. To use Mouse Mode, first set a keyboard hotkey for it under [User Settings](#user-settings). Once in a tower, press this hotkey to enable Mouse Mode. The tower controls will fade out slightly and message will appear at the bottom of the screen confirming that you've entered Mouse Mode. Clicking on the screen will ring the bell in the bottom-right of the circle (if you're not assigned to any bells) or your lowest-numbered assigned bell. Press the same hotkey again to disable Mouse Mode.
 
 ### Listener links
 

--- a/app/templates/help.md
+++ b/app/templates/help.md
@@ -214,7 +214,7 @@ The **Keyboard** tab allows you to customize the keyboard hotkeys used to contro
 -   **Rounds**: Call "Rounds" (Defaults: `o`, `O`)
 -   **Change method**: Call "Change method" (Defaults: `c`, `C`)
 -   **Sorry**: Apologize (Defaults: `s`)
-- **Mouse Mode**: Enable a [mouse-only accessibility mode](#mouse-mode) (Defaults: none)
+- **Mouse Mode**: Enable a [mouse-only accessibility mode](#additional-features) (Defaults: none)
 -   **Ring bell 1–16**: (Advanced) Ring specific bell (Defaults: `1–9`, `0`, `-`, `=`, `q`, `w`, `e`, `r`)
 -   **Rotate to 1–16**: (Advanced) Rotate the circle so that a given bell is in the bottom-right (Defaults: `shift + 1–9`, `0`, `-`, `=`, `q`, `w`, `e`, `r`)
 -   **Catch hold of 1–16**: (Advanced) Assign yourself to the given bell. (Defaults: `ctrl + shift + 1-9`, `0`, `-`, `=`, `q`, `w`, `e`, `r` on Windows` , ``cmd + shift+ 1-9 `, `0`, `-`, `= ,q`, `e`, `r` on Mac.)

--- a/config.py
+++ b/config.py
@@ -99,6 +99,7 @@ class Config(object):
             "catch-16": ["meta+shift+r"],
             "flip-left": ["a", "shift+a"],
             "flip-right": [";", "shift+;"],
+            "overlay": [],
         },
         "controllers": {
             "debounce": 600,


### PR DESCRIPTION
Adds a new accessibility feature: "Mouse Mode"

Mouse Mode disables all on-screen controls, and instead interprets a click anywhere on the screen as "ring right-hand bell". This mode can be enabled and disabled via a hotkey. By default, the hotkey is not set — so no one should be able to enable this mode by default. The user can add a hotkey in the User Settings.
