### PR TITLE
Actually save UserTowerRelations

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -116,6 +116,7 @@ class User(UserMixin, db.Model):
             # Just creating this is enough to add it to the database with
             # relevant relations
             rel = UserTowerRelation(user=self, tower=tower)
+            db.session.add(rel)
 
         return rel
 


### PR DESCRIPTION
The `UserTowerRelation` was not getting saved on tower creation, resulting in users not having admin rights to the tower (or having it show up in their recents).